### PR TITLE
Remove exploit

### DIFF
--- a/lua/autorun/server/!!!say_no_to_exploits_sv.lua
+++ b/lua/autorun/server/!!!say_no_to_exploits_sv.lua
@@ -280,7 +280,6 @@ local exploitable_nets = {
 	"PurchaseWeed",
 	"guncraft_removeWorkbench",
 	"userAcceptPrestige",
-	"vj_npcspawner_sv_create",
 	"DuelMessageReturn",
 	"Client_To_Server_OpenEditor",
 	"GiveSCP294Cup",


### PR DESCRIPTION
Hello,
Following the SNTE patch, targeting the `vj_npcspawner_sv_create` network is no longer useful (especially since it no longer exists).

